### PR TITLE
Docker support for contrail-test-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM hkumar/ubuntu-14.04.2
+MAINTAINER Juniper Contrail <contrail@juniper.net>
+ARG CONTRAIL_TEST_CI_REPO=https://github.com/juniper/contrail-test-ci
+ARG CONTRAIL_TEST_CI_BRANCH=master
+ARG CONTRAIL_INSTALL_PACKAGE_URL
+ARG ENTRY_POINT=docker_entrypoint_ci.sh
+ARG CONTRAIL_FAB_REPO=https://github.com/juniper/contrail-fabric-utils
+ARG CONTRAIL_FAB_BRANCH=master
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Just check if $CONTRAIL_INSTALL_PACKAGE_URL is there, if not valid, build will fail
+RUN wget -q --spider $CONTRAIL_INSTALL_PACKAGE_URL
+
+# setup contrail-install-packages
+RUN wget $CONTRAIL_INSTALL_PACKAGE_URL -O /contrail-install-packages.deb && \
+    dpkg -i /contrail-install-packages.deb && \
+    rm -f /contrail-install-packages.deb && \
+    cd /opt/contrail/contrail_packages/ && ./setup.sh && \
+    apt-get install -y python-pip ant python-dev python-novaclient python-neutronclient python-cinderclient \
+                    python-contrail patch python-heatclient python-ceilometerclient python-setuptools \
+                    libxslt1-dev libz-dev libyaml-dev git python-glanceclient && \
+                    rm -fr /opt/contrail/* ; apt-get -y autoremove && apt-get -y clean
+RUN git clone $CONTRAIL_TEST_CI_REPO -b $CONTRAIL_TEST_CI_BRANCH /contrail-test
+RUN cd /contrail-test && pip install --upgrade -r requirements.txt
+RUN git clone $CONTRAIL_FAB_REPO -b $CONTRAIL_FAB_BRANCH /opt/contrail/utils
+COPY $ENTRY_POINT /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/docker_entrypoint_ci.sh
+++ b/docker_entrypoint_ci.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash -x
+
+while getopts ":t:p:" opt; do
+  case $opt in
+    t)
+      testbed_input=$OPTARG
+      ;;
+    p)
+      contrail_fabpath_input=$OPTARG
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+TESTBED=${testbed_input:-${TESTBED:-'/opt/contrail/utils/fabfile/testbeds/testbed.py'}}
+CONTRAIL_FABPATH=${contrail_fabpath_input:-${CONTRAIL_FABPATH:-'/opt/contrail/utils'}}
+
+if [[ ( ! -f /contrail-test/sanity_params.ini || ! -f /contrail-test/sanity_testbed.json ) && ! -f $TESTBED ]]; then
+    echo "ERROR! Either testbed file or sanity_params.ini or sanity_testbed.json under /contrail-test is required.
+          you probably forgot to attach them as volumes"
+    exit 100
+fi
+
+if [ ! $TESTBED -ef ${CONTRAIL_FABPATH}/fabfile/testbeds/testbed.py ]; then
+    mkdir -p ${CONTRAIL_FABPATH}/fabfile/testbeds/
+    cp $TESTBED ${CONTRAIL_FABPATH}/fabfile/testbeds/testbed.py
+fi
+
+cd /contrail-test
+./run_ci.sh --contrail-fab-path $CONTRAIL_FABPATH


### PR DESCRIPTION
This patch is to add Dockerfile, and entrypoint script. This will enable
docker build contrail-test-ci using docker build

E.g

docker build --no-cache -t hkumar/contrail-test-juno:2.21-105
--build-arg
CONTRAIL_INSTALL_PACKAGE_URL=http://nodei16/contrail-install-packages_2.21-105~juno_all.deb

It support multiple build args, please see Dockerfile for more details
(ARG keywords).
