### PR TITLE
Changed shebang

### DIFF
--- a/docker/ci/docker_entrypoint_ci.sh
+++ b/docker/ci/docker_entrypoint_ci.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -x
+#!/bin/bash
 
 while getopts ":t:p:" opt; do
   case $opt in


### PR DESCRIPTION
env bash -x was throwing error as bash -x is not an executable, so changed it to /bin/bash
