### PR TITLE
Changes regarding email report and cirros image for ci_tests

### DIFF
--- a/configs/images.cfg
+++ b/configs/images.cfg
@@ -29,6 +29,7 @@ params          = --container-format bare --disk-format vmdk --property vmware_d
 name_docker     = phusion-baseimage-enablesshd
 #params    = --container-format ovf --disk-format qcow2 --property hypervisor_type=qemu
 
+# This image is available in ci docker image
 [cirros-0.3.0-x86_64-uec]
 name      = cirros-0.3.0-x86_64-disk.vmdk.gz
 username  = cirros

--- a/fixtures/nova_test.py
+++ b/fixtures/nova_test.py
@@ -190,7 +190,6 @@ class NovaHelper():
     # end _install_flavor
 
     def _install_image(self, image_name):
-        result = False
         self.logger.debug('Installing image %s'%image_name)
         image_info = self.images_info[image_name]
         webserver = image_info['webserver'] or \
@@ -199,7 +198,10 @@ class NovaHelper():
         params = image_info['params']
         image = image_info['name']
         image_type = image_info['type']
-        if re.match(r'^file://', location):
+        contrail_test_path = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)),'..'))
+        if contrail_test_path and os.path.isfile("%s/images/%s" % (contrail_test_path, image_name)):
+            build_path = "file://%s/images/%s" % (contrail_test_path, image_name)
+        elif re.match(r'^file://', location):
             build_path = '%s/%s' % (location, image)
         else:
             build_path = 'http://%s/%s/%s' % (webserver, location, image)

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -36,6 +36,7 @@ send_mail=0
 concurrency=""
 parallel=0
 contrail_fab_path='/opt/contrail/utils'
+export SCRIPT_TS=${SCRIPT_TS:-$(date +"%Y_%m_%d_%H_%M_%S")}
 
 if ! options=$(getopt -o UthdC:lLmc: -l upload,parallel,help,debug,config:,logging,logging-config,send-mail,concurrency:,contrail-fab-path: -- "$@")
 then


### PR DESCRIPTION
* email the report by default
* download and keep cirros image in the docker image
* configure images.cfg to upload cirros image from local filesystem
* set ci_image to be cirros image to use that image for ci tests
* Set script_ts environment variable to solve sendmail issue