### PR TITLE
If user role mapping already exists, just add it as a debug log

### DIFF
--- a/fixtures/keystone_tests.py
+++ b/fixtures/keystone_tests.py
@@ -79,7 +79,10 @@ class KeystoneCommands():
         try:
             self.keystone.tenants.add_user(tenant, user, role)
         except ks_exceptions.Conflict as e:
-            LOG.logger.info(str(e))
+            if 'already has role' in str(e):
+                LOG.logger.debug(str(e))
+            else:
+                LOG.logger.info(str(e))
 
     def remove_user_from_tenant(self, tenant, user, role):
 


### PR DESCRIPTION
Otherwise, users running the tests may see it as an error
condition