### PR TITLE
Fixing typo in run_ci.sh

### DIFF
--- a/run_ci.sh
+++ b/run_ci.sh
@@ -61,7 +61,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-testargs+=" $test_tag"
+testrargs+=" $test_tag"
 export TAGS="$test_tag"
 
 if [ -n "$config_file" ]; then

--- a/tools/report_gen.py
+++ b/tools/report_gen.py
@@ -176,6 +176,8 @@ class ContrailReportInit:
                 if role['type'] == 'openstack':
                     if self.keystone_ip:
                         self.openstack_ip = self.keystone_ip
+                        self.host_data[self.openstack_ip] = \
+                                       self.host_data[host_ip]
                     else:
                         self.openstack_ip = host_ip
                         self.keystone_ip = host_ip


### PR DESCRIPTION
Fixing key not found issue during report generation in case of keystone_ip is not same as openstack ip