### PR TITLE
Use ssh agent to connect between remote machines

### DIFF
--- a/fixtures/vm_test.py
+++ b/fixtures/vm_test.py
@@ -1714,21 +1714,14 @@ class VMFixture(fixtures.Fixture):
         timeout = math.floor(40 * float(delay_factor))
 
         try:
-            self.orch.put_key_file_to_host(self.vm_node_ip)
-            with hide('everything'):
-                with settings(host_string='%s@%s' % (
-                              host['username'], self.vm_node_ip),
-                              password=host['password'],
-                              warn_only=True, abort_on_prompts=False):
-                    self.get_rsa_to_vm()
-                    i = 'timeout %d scp -o StrictHostKeyChecking=no -i id_rsa %s %s@[%s]:' % (
-                        timeout, file, dest_vm_username, vm_ip)
-                    cmd_outputs = self.run_cmd_on_vm(
-                        cmds=[i], timeout=timeout + 10)
-                    self.logger.debug(cmd_outputs)
+            i = 'timeout %d scp -o StrictHostKeyChecking=no %s %s@[%s]:' % (
+                timeout, file, dest_vm_username, vm_ip)
+            cmd_outputs = self.run_cmd_on_vm(
+                cmds=[i], timeout=timeout + 10)
+            self.logger.debug(cmd_outputs)
         except Exception, e:
             self.logger.exception(
-                'Exception occured while trying to scp the file ')
+                'Exception occured while trying to scp the file\n%s' % e)
     # end scp_file_to_vm
 
     def put_pub_key_to_vm(self):

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -13,6 +13,7 @@ function usage {
   echo "Usage: $0 [OPTION]..."
   echo "Run Contrail test suite"
   echo ""
+  echo "  -p, --prepare            Run only preparation steps"
   echo "  -t, --parallel           Run testr in parallel"
   echo "  -h, --help               Print this usage message"
   echo "  -m, --send-mail          Send the report at the end"
@@ -20,6 +21,7 @@ function usage {
   echo "  --contrail-fab-path      Contrail fab path, default to /opt/contrail/utils"
   echo "  -- [TESTROPTIONS]        After the first '--' you can pass arbitrary arguments to testr "
 }
+
 testrargs=""
 debug=0
 force=0
@@ -34,7 +36,29 @@ contrail_fab_path='/opt/contrail/utils'
 test_tag='suite1'
 export SCRIPT_TS=${SCRIPT_TS:-$(date +"%Y_%m_%d_%H_%M_%S")}
 
-if ! options=$(getopt -o UthdC:lLmc: -l upload,parallel,help,debug,config:,logging,logging-config,send-mail,concurrency:,contrail-fab-path: -- "$@")
+function prepare {
+  if [ -n "$config_file" ]; then
+    config_file=`readlink -f "$config_file"`
+    export TEST_CONFIG_DIR=`dirname "$config_file"`
+    export TEST_CONFIG_FILE=`basename "$config_file"`
+  fi
+
+  if [ ! -f "$config_file" ]; then
+    python tools/configure.py $(readlink -f .) -p $contrail_fab_path
+  fi
+
+  #Start ssh-agent if not there
+  if [ -z "$SSH_AUTH_SOCK" ] ; then
+    eval `ssh-agent -s`
+  fi
+  if [ -z "$SSH_AUTH_SOCK" ] ; then
+    echo "Error: SSH agent failed to start"
+    exit 1
+  fi
+  ssh-add
+}
+
+if ! options=$(getopt -o pUthdC:lLmc: -l prepare,upload,parallel,help,debug,config:,logging,logging-config,send-mail,concurrency:,contrail-fab-path: -- "$@")
 then
     # parse error
     usage
@@ -45,6 +69,7 @@ eval set -- $options
 first_uu=yes
 while [ $# -gt 0 ]; do
   case "$1" in
+    -p|--prepare) prepare; exit;;
     -h|--help) usage; exit;;
     -U|--upload) upload=1;;
     -d|--debug) debug=1;;
@@ -64,15 +89,7 @@ done
 testrargs+=" $test_tag"
 export TAGS="$test_tag"
 
-if [ -n "$config_file" ]; then
-    config_file=`readlink -f "$config_file"`
-    export TEST_CONFIG_DIR=`dirname "$config_file"`
-    export TEST_CONFIG_FILE=`basename "$config_file"`
-fi
-
-if [ ! -f "$config_file" ]; then
-    python tools/configure.py $(readlink -f .) -p $contrail_fab_path
-fi
+prepare
 
 if [ $logging -eq 1 ]; then
     if [ ! -f "$logging_config" ]; then

--- a/tcutils/util.py
+++ b/tcutils/util.py
@@ -252,6 +252,7 @@ def run_cmd_through_node(host_string, cmd, password=None, gateway=None,
                                       shell=shell,
                                       disable_known_hosts=True,
                                       abort_on_prompts=False):
+        env.forward_agent = True
         gateway_hoststring = gateway if re.match(r'\w+@[\d\.]+:\d+', gateway) else gateway + ':22'
         node_hoststring = host_string if re.match(r'\w+@[\d\.]+:\d+', host_string) else host_string + ':22'
         if password:


### PR DESCRIPTION
Current method - copy ssh private key to remote node1 and then try to
ssh using that key file - is not required, as ssh-agent forwarding will
enable such facility without ssh private keys present in subsequent
machines. You just need private key on test node and no need to copy
private key to anywhere else, just run ssh-agent on test node and run
the command on remote nodes (even between remote nodes with agent
forwarding enabled.

Added a new function "prepare" in run_ci.sh and also added a new
parameter to run only "prepare". This will be helpful in case of
manually running tests which actually need running tools/configure.py as
well as starting ssh-agent on test node.