### PR TITLE
Fix sshable hung issue

### DIFF
--- a/tcutils/util.py
+++ b/tcutils/util.py
@@ -366,13 +366,11 @@ def sshable(host_string, password=None, gateway=None, gateway_password=None):
                                       password=gateway_password,
                                       warn_only=True):
         if run('nc -w 1 -z %s %s' % (host_string_split[1], host_port)).succeeded:
-            try:
-                run_cmd_through_node(host_string, 'uname', password, gateway,
-                                     gateway_password, timeout=10)
+            time.sleep(5)
+            if run('nc -w 1 -z %s %s' % (host_string_split[1], host_port)).succeeded:
                 return True
-            except Exception as e:
+            else:
                 log.error("Error on ssh to %s" % host_string)
-                log.debug(str(e))
                 return False
 
 


### PR DESCRIPTION
 Sometimes run_cmd_through_node is just hung especially on sshable, per
previous experience it should be because of the way paramiko behave in
case ssh is not full up. So instead of doing fab, sshable will check the
port is up  and declare sshable if it succeed two consecutive times in
duration of 5 seconds.